### PR TITLE
Integrate output format & update the test code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bcR
 Type: Package
 Title: A simple base converter: implements the numeral systems conversion
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: person("Daeyoung", "Kim", email = "daykim22@gmail.com", role = c("aut", "cre"))
 Description: This packages implements the numeral systems conversion for R using GNU bc.
 Depends:

--- a/R/convertBase.R
+++ b/R/convertBase.R
@@ -43,7 +43,7 @@ convertBase <- function(x, inputBase, outputBase) {
     Vectorize(FUN = .convertBaseScalar,
               vectorize.args = 'x')
   
-  return(.convertBaseVectorized(x, inputBase, outputBase))
+  return(.convertBaseVectorized(as.character(x), inputBase, outputBase))
 }
 
 #' Which numeral bases are convertible

--- a/tests/testthat/test_convertBase.R
+++ b/tests/testthat/test_convertBase.R
@@ -3,47 +3,60 @@ context('Converting number bases')
 # 2 -> X
 test_that("Convert base: 2 -> 2", {
   expect_equal(object = convertBase(11, 2, 2),
-               expected =  '11')
+               expected =  c('11' = '11'))
 })
 
 test_that("Convert base: 2 -> 10", {
   expect_equal(object = convertBase(11, 2, 10),
-               expected =  3)
+               expected =  c('11' = 3))
 })
 
 test_that("Convert base: 2 -> 16", {
   expect_equal(object = convertBase(11, 2, 16),
-               expected =  '3')
+               expected =  c('11' = '3'))
 })
 
 # 10 -> X
 test_that("Convert base: 10 -> 2", {
   expect_equal(object = convertBase(11, 10, 2),
-               expected =  '1011')
+               expected =  c('11' = '1011'))
 })
 
 test_that("Convert base: 10 -> 10", {
   expect_equal(object = convertBase(11, 10, 10),
-               expected =  11)
+               expected =  c('11' = 11))
 })
 
 test_that("Convert base: 10 -> 16", {
   expect_equal(object = convertBase(11, 10, 16),
-               expected =  'B')
+               expected =  c('11' = 'B'))
 })
 
 # 16 -> X
 test_that("Convert base: 16 -> 2", {
   expect_equal(object = convertBase(11, 16, 2),
-               expected =  '10001')
+               expected =  c('11' = '10001'))
+})
+test_that("Convert base: 16 -> 2", {
+  expect_equal(object = convertBase('A', 16, 2),
+               expected =  c('A' = '1010'))
 })
 
 test_that("Convert base: 16 -> 10", {
   expect_equal(object = convertBase(11, 16, 10),
-               expected =  17)
+               expected =  c('11' = 17))
+})
+test_that("Convert base: 16 -> 10", {
+  expect_equal(object = convertBase('A', 16, 10),
+               expected =  c('A' = 10))
 })
 
 test_that("Convert base: 16 -> 16", {
   expect_equal(object = convertBase(11, 16, 16),
-               expected =  '11')
+               expected =  c('11' = '11'))
 })
+test_that("Convert base: 16 -> 16", {
+  expect_equal(object = convertBase('A', 16, 16),
+               expected =  c('A' = 'A'))
+})
+


### PR DESCRIPTION
- In previous versions, if input value for `convertBase()` is not `character`, returned value was not named.
  - `convertBase(10, '16', '10')` returns unnamed 16
  - `convertBase('A', '16', '10')` returns 10 with name `A`
- From version `0.1.2` every returned value has name with its input value.
  - `convertBase(10, '16', '10')` returns 16 with name `10`
